### PR TITLE
Add esn-frontend-common-libs explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "AGPLv3",
   "dependencies": {
+    "esn-frontend-common-libs": "github:linagora/esn-frontend-common-libs#main",
     "esn-frontend-inbox": "github:linagora/esn-frontend-inbox#main",
     "esn-frontend-inbox-linshare": "github:linagora/esn-frontend-inbox-linshare#main"
   },


### PR DESCRIPTION
`sessionFactory` service defined in [esn-frontend-common-libs](https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/) is used, but the dependency is used via child dependency, it should be needed as explicit dependency.